### PR TITLE
Fix minor compile errors in mod code

### DIFF
--- a/Source/FleshSymbiontMod/ModSettings.cs
+++ b/Source/FleshSymbiontMod/ModSettings.cs
@@ -586,3 +586,4 @@ namespace FleshSymbiontMod
             return "Signal Lost";
         }
     }
+}

--- a/Source/FleshSymbiontMod/Workers/RecipeWorker_ExtractXenogerm.cs
+++ b/Source/FleshSymbiontMod/Workers/RecipeWorker_ExtractXenogerm.cs
@@ -130,7 +130,7 @@ namespace FleshSymbiontMod
                 string message = FleshSymbiontSettings.messageFrequency switch
                 {
                     3 => $"The extraction is successful, but at a terrible cost. The symbiont's agonized shriek echoes " +
-                         "through the colony as Dr. {doctor?.Name.ToStringShort ?? "Unknown"} pulls free a writhing mass of " +
+                         $"through the colony as Dr. {doctor?.Name.ToStringShort ?? "Unknown"} pulls free a writhing mass of " +
                          "alien genetic material. The xenogerm pulses with its own malevolent life, and the doctor's " +
                          "hands are stained with something that isn't quite blood...",
                          


### PR DESCRIPTION
## Summary
- add missing namespace closing brace in ModSettings
- fix string interpolation in xenogerm extraction worker

## Testing
- `dotnet build` *(fails: missing overrides and duplicates)*

------
https://chatgpt.com/codex/tasks/task_e_6891bb3494b88325913d208f6eb13d95