### PR TITLE
Fix ToStringShort property usage in SymbiontUtility

### DIFF
--- a/Source/FleshSymbiontMod/Utilities/SymbiontUtility.cs
+++ b/Source/FleshSymbiontMod/Utilities/SymbiontUtility.cs
@@ -56,7 +56,7 @@ namespace FleshSymbiontMod
             
             if (FleshSymbiontSettings.enableHorrorMessages)
             {
-                string casterText = caster != null ? $" {caster.Name.ToStringShort()}'s" : "";
+                string casterText = caster != null ? $" {caster.Name.ToStringShort}'s" : "";
                 string message = Extensions.GetHorrorIntensityMessage(
                     $"{target.Name.ToStringShort} resists{casterText} psychic compulsion.",
                     $"{target.Name.ToStringShort} resists{casterText} psychic compulsion through sheer willpower!",


### PR DESCRIPTION
## Summary
- Use `ToStringShort` property correctly when forming compulsion resistance messages

## Testing
- `dotnet build Source/FleshSymbiontMod/FleshSymbiontMod.csproj` *(fails: Syntax error, ',' expected in RecipeWorker_ExtractXenogerm.cs; } expected in ModSettings.cs)*

------
https://chatgpt.com/codex/tasks/task_e_6891c7417e54832583f0f94efaecd6d9