### PR TITLE
Expand mod descriptions with RimWorld lore

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -3,17 +3,17 @@
   <name>Signal Lost</name>
   <author>Higgs</author>
   <packageId>zph.signallost</packageId>
-  <description>A Lovecraftian horror event for RimWorld Anomaly. Discover grotesque flesh symbionts that actively hunt your colonists for parasitic bonding.
+  <description>A Lovecraftian horror event woven into RimWorld lore. Long-range comms whisper of a "lost signal" emanating from deep beneath the crust. Colonists unearth grotesque flesh symbionts—rumored remnants of forgotten archotech biolabs—that stalk the frontier seeking hosts.
 
 Features:
-- Flesh symbionts that appear as buried anomalies
-- Psychic compulsion system that forces colonists to approach
-- Parasitic bonding with powerful enhancements and terrible costs
-- Escalating hunger mechanics that make the symbiont more aggressive over time
-- Defensive behaviors when threatened
+- Flesh symbionts erupting from buried anomaly sites
+- Psychic compulsions reminiscent of ancient archotech lures
+- Parasitic bonding that grants power at the cost of sanity
+- Escalating hunger that drives the symbiont to lash out
+- Defensive reflexes when threatened
 - Full integration with Anomaly research systems
 
-Warning: This mod contains body horror themes inspired by Dead Space and Lovecraftian fiction.
+Warning: Contains body horror themes inspired by Dead Space and RimWorld's strangest tales.
 
 Developed with assistance from Claude AI (Anthropic).</description>
   <supportedVersions>

--- a/Defs/Abilities/SymbiontPsycasts.xml
+++ b/Defs/Abilities/SymbiontPsycasts.xml
@@ -5,7 +5,7 @@
   <AbilityDef ParentName="PsycastBase">
     <defName>SymbiontCompel</defName>
     <label>symbiont compel</label>
-    <description>Channel the symbiont's psychic influence to compel a target to approach and bond with a nearby flesh symbiont. The target will be unable to resist the alien whispers.
+    <description>Channel the symbiont's psychic influence to compel a target to approach and bond with a nearby flesh symbiont. The lure echoes the psylink sirens of ancient cults, leaving the target unable to resist the alien whispers.
 
 The compulsion strength is enhanced by the caster's bond with their symbiont.</description>
     <iconPath>UI/Abilities/SymbiontCompel</iconPath>
@@ -205,7 +205,7 @@ WARNING: This ability may trigger symbiont madness in weakened minds.</descripti
   <AbilityGroupDef>
     <defName>Symbiont</defName>
     <label>symbiont</label>
-    <description>Psychic abilities granted by symbiont bonding</description>
+    <description>Psycasts taught by the symbiont hive-mind, merging human psylinks with alien instinct.</description>
     <iconPath>UI/Icons/AbilityGroups/Symbiont</iconPath>
   </AbilityGroupDef>
 

--- a/Defs/Buildings/Building_FleshSymbiont.xml
+++ b/Defs/Buildings/Building_FleshSymbiont.xml
@@ -5,11 +5,11 @@
   <ThingDef ParentName="BuildingBase">
     <defName>FleshSymbiont</defName>
     <label>flesh symbiont</label>
-    <description>A grotesque biomechanical entity of unknown origin. Its ribbed, hand-like appendage pulses with alien life, while complex neural networks beneath its translucent flesh suggest a form of directed intelligence.
+    <description>A grotesque biomechanical growth of uncertain origin. Some spacer scholars whisper that it's an archotech seed left to fester. Its ribbed, hand-like appendage pulses with alien life while neural lattices beneath translucent flesh hint at a patient intelligence.
 
-The symbiont emanates a psychic presence that compels nearby humans to approach and bond with it. Once bonded, the host gains enhanced abilities but at the cost of their humanity.
+The symbiont radiates a siren-like psychic field that draws in nearby colonists. Those who bond gain unnatural strength, but each tendril erodes their humanity.
 
-WARNING: Prolonged exposure may result in psychological contamination.</description>
+WARNING: Prolonged exposure has driven entire frontier settlements into madness.</description>
     <thingClass>FleshSymbiontMod.Building_FleshSymbiont</thingClass>
     <category>Building</category>
     <graphicData>

--- a/Defs/Research/SymbiontResearch.xml
+++ b/Defs/Research/SymbiontResearch.xml
@@ -5,9 +5,9 @@
   <ResearchProjectDef>
     <defName>FleshSymbiontStudy</defName>
     <label>flesh symbiont study</label>
-    <description>Study the biomechanical flesh symbiont to understand its origins and potentially find ways to safely remove or control the parasitic bond.
+    <description>Study the biomechanical flesh symbiont, suspected relics of abandoned archotech bio-labs, to understand its origins and find ways to safely remove or control the parasitic bond.
 
-This research may unlock methods to resist compulsion and develop countermeasures against the entity's influence.</description>
+This research may unlock methods to resist its siren call and develop countermeasures against the entity's influence.</description>
     <baseCost>3000</baseCost>
     <techLevel>Spacer</techLevel>
     <prerequisites>

--- a/Defs/SignalLost.xml
+++ b/Defs/SignalLost.xml
@@ -5,11 +5,11 @@
   <ThingDef ParentName="BuildingBase">
     <defName>FleshSymbiont</defName>
     <label>flesh symbiont</label>
-    <description>A grotesque biomechanical entity of unknown origin. Its ribbed, hand-like appendage pulses with alien life, while complex neural networks beneath its translucent flesh suggest a form of directed intelligence.
+    <description>A grotesque biomechanical growth of uncertain origin. Some spacer scholars whisper that it's an archotech seed left to fester. Its ribbed, hand-like appendage pulses with alien life while neural lattices beneath translucent flesh hint at a patient intelligence.
 
-	The symbiont emanates a psychic presence that compels nearby humans to approach and bond with it. Once bonded, the host gains enhanced abilities but at the cost of their humanity.
+        The symbiont radiates a siren-like psychic field that draws in nearby colonists. Those who bond gain unnatural strength, but each tendril erodes their humanity.
 
-	WARNING: Prolonged exposure may result in psychological contamination.</description>
+        WARNING: Prolonged exposure has driven entire frontier settlements into madness.</description>
     <thingClass>FleshSymbiontMod.Building_FleshSymbiont</thingClass>
     <category>Building</category>
     <graphicData>


### PR DESCRIPTION
## Summary
- Flesh out mod manifest with RimWorld archotech myths
- Add archotech speculation to flesh symbiont building descriptions
- Reference archotech relics in research and psycast text

## Testing
- `dotnet test Source/FleshSymbiontMod.Tests`

------
https://chatgpt.com/codex/tasks/task_e_6893461d47a48325a75f050e22f3e20c